### PR TITLE
Init proyecto React con ejemplos de librerías

### DIFF
--- a/examples/auth.tsx
+++ b/examples/auth.tsx
@@ -1,0 +1,13 @@
+import { signIn, signOut, useSession } from "next-auth/react";
+
+export default function AuthButton() {
+  const { data: session } = useSession();
+  return session ? (
+    <>
+      <span>{session.user?.email}</span>
+      <button onClick={() => signOut()}>Salir</button>
+    </>
+  ) : (
+    <button onClick={() => signIn("github")}>Entrar</button>
+  );
+}

--- a/examples/chartjs.tsx
+++ b/examples/chartjs.tsx
@@ -1,0 +1,23 @@
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Doughnut } from "react-chartjs-2";
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+const data = {
+  labels: ["Rojo", "Azul", "Amarillo"],
+  datasets: [
+    {
+      data: [12, 19, 3],
+      backgroundColor: ["#f00", "#00f", "#ff0"],
+    },
+  ],
+};
+
+export function Grafica() {
+  return <Doughnut data={data} />;
+}

--- a/examples/dayjs.tsx
+++ b/examples/dayjs.tsx
@@ -1,0 +1,5 @@
+import dayjs from "dayjs";
+
+const now = dayjs();
+const formatted = now.format("DD/MM/YYYY");
+console.log(formatted);

--- a/examples/drag-and-drop.tsx
+++ b/examples/drag-and-drop.tsx
@@ -1,0 +1,19 @@
+import { createDragAndDrop } from "@formkit/drag-and-drop";
+import { useEffect, useRef } from "react";
+
+export default function Lista() {
+  const ref = useRef<HTMLUListElement | null>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      createDragAndDrop(ref.current);
+    }
+  }, []);
+
+  return (
+    <ul ref={ref}>
+      <li>Elemento 1</li>
+      <li>Elemento 2</li>
+    </ul>
+  );
+}

--- a/examples/fontsource.tsx
+++ b/examples/fontsource.tsx
@@ -1,0 +1,5 @@
+import "@fontsource/roboto/400.css";
+
+export default function App() {
+  return <div style={{ fontFamily: "Roboto" }}>Texto con Roboto</div>;
+}

--- a/examples/hotkeys.tsx
+++ b/examples/hotkeys.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import hotkeys from "hotkeys-js";
+
+export default function Hotkeys() {
+  useEffect(() => {
+    hotkeys("ctrl+k", (event) => {
+      event.preventDefault();
+      console.log("Abrir buscador");
+    });
+
+    return () => {
+      hotkeys.unbind("ctrl+k");
+    };
+  }, []);
+
+  return null;
+}

--- a/examples/motion.tsx
+++ b/examples/motion.tsx
@@ -1,0 +1,9 @@
+import { motion } from "framer-motion";
+
+export default function FadeIn() {
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+      Hola mundo
+    </motion.div>
+  );
+}

--- a/examples/react-table.tsx
+++ b/examples/react-table.tsx
@@ -1,0 +1,54 @@
+import {
+  useReactTable,
+  getCoreRowModel,
+  flexRender,
+  ColumnDef,
+} from "@tanstack/react-table";
+
+interface Person {
+  name: string;
+  age: number;
+}
+
+const columns: ColumnDef<Person>[] = [
+  { accessorKey: "name", header: "Nombre" },
+  { accessorKey: "age", header: "Edad" },
+];
+
+export function Tabla({ data }: { data: Person[] }) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <table>
+      <thead>
+        {table.getHeaderGroups().map((group) => (
+          <tr key={group.id}>
+            {group.headers.map((header) => (
+              <th key={header.id}>
+                {flexRender(
+                  header.column.columnDef.header,
+                  header.getContext()
+                )}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr key={row.id}>
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id}>
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/examples/zod.tsx
+++ b/examples/zod.tsx
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+const schema = z.object({
+  email: z.string().email(),
+});
+
+export function handleSubmit(data: unknown) {
+  const parsed = schema.safeParse(data);
+  if (!parsed.success) {
+    console.error(parsed.error.format());
+  }
+}

--- a/examples/zustand.tsx
+++ b/examples/zustand.tsx
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+
+type Store = {
+  count: number;
+  inc: () => void;
+};
+
+const useStore = create<Store>((set) => ({
+  count: 0,
+  inc: () => set((state) => ({ count: state.count + 1 })),
+}));
+
+export function Counter() {
+  const { count, inc } = useStore();
+  return <button onClick={inc}>{count}</button>;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Libraries</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "libraries",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@fontsource/roboto": "^5.0.8",
+    "@formkit/drag-and-drop": "^0.5.0",
+    "@tanstack/react-table": "^8.10.0",
+    "chart.js": "^4.4.0",
+    "dayjs": "^1.11.10",
+    "framer-motion": "^10.16.0",
+    "hotkeys-js": "^3.12.0",
+    "next-auth": "^4.24.5",
+    "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.2.0",
+    "zod": "^3.22.4",
+    "zustand": "^4.4.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "typescript": "^5.0.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,5 @@
+export default function App() {
+  return (
+    <h1>React Libraries Examples</h1>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,4 @@
+#root {
+  font-family: sans-serif;
+  padding: 2rem;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Resumen
- Inicializa proyecto React con Vite y configuración TypeScript.
- Agrega carpeta `examples` con ejemplos para Zod, Day.js, TanStack Table, Auth.js, Framer Motion, Fontsource, Chart.js, Zustand, FormKit drag-and-drop y Hotkeys.
- Define dependencias de todas las librerías en `package.json`.

## Pruebas
- `npm install` *(falló: 403 Forbidden - GET https://registry.npmjs.org/@fontsource%2froboto)*
- `npm run build` *(falló: Cannot find module 'react')*


------
https://chatgpt.com/codex/tasks/task_e_689cac56d6b083229d98c9ead73be996