### PR TITLE
feat: add example navigation header

### DIFF
--- a/examples/dayjs.tsx
+++ b/examples/dayjs.tsx
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 
-const now = dayjs();
-const formatted = now.format("DD/MM/YYYY");
-console.log(formatted);
+export default function DayjsExample() {
+  const formatted = dayjs().format("DD/MM/YYYY");
+  return <div>{formatted}</div>;
+}

--- a/examples/zod.tsx
+++ b/examples/zod.tsx
@@ -4,9 +4,7 @@ const schema = z.object({
   email: z.string().email(),
 });
 
-export function handleSubmit(data: unknown) {
-  const parsed = schema.safeParse(data);
-  if (!parsed.success) {
-    console.error(parsed.error.format());
-  }
+export default function ZodExample() {
+  const result = schema.safeParse({ email: "correo" });
+  return <pre>{JSON.stringify(result, null, 2)}</pre>;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,56 @@
+import { useEffect, useState } from "react";
+import { Grafica } from "../examples/chartjs";
+import Lista from "../examples/drag-and-drop";
+import FontApp from "../examples/fontsource";
+import Hotkeys from "../examples/hotkeys";
+import FadeIn from "../examples/motion";
+import { Tabla } from "../examples/react-table";
+import { Counter } from "../examples/zustand";
+import DayjsExample from "../examples/dayjs";
+import ZodExample from "../examples/zod";
+
+const examples = [
+  { slug: "chartjs", label: "ChartJS", element: <Grafica /> },
+  { slug: "drag-and-drop", label: "Drag & Drop", element: <Lista /> },
+  { slug: "fontsource", label: "Fontsource", element: <FontApp /> },
+  { slug: "hotkeys", label: "Hotkeys", element: <Hotkeys /> },
+  { slug: "motion", label: "Motion", element: <FadeIn /> },
+  {
+    slug: "react-table",
+    label: "React Table",
+    element: <Tabla data={[{ name: "Juan", age: 30 }]} />,
+  },
+  { slug: "zustand", label: "Zustand", element: <Counter /> },
+  { slug: "dayjs", label: "Dayjs", element: <DayjsExample /> },
+  { slug: "zod", label: "Zod", element: <ZodExample /> },
+];
+
 export default function App() {
+  const [example, setExample] = useState<string>(
+    window.location.hash.replace("#", "")
+  );
+
+  useEffect(() => {
+    const handler = () => setExample(window.location.hash.replace("#", ""));
+    window.addEventListener("hashchange", handler);
+    return () => window.removeEventListener("hashchange", handler);
+  }, []);
+
+  const current = examples.find((e) => e.slug === example);
+
   return (
-    <h1>React Libraries Examples</h1>
+    <>
+      <header>
+        <nav>
+          <a href="#">Inicio</a>
+          {examples.map((e) => (
+            <a key={e.slug} href={`#${e.slug}`}>
+              {e.label}
+            </a>
+          ))}
+        </nav>
+      </header>
+      <main>{current ? current.element : <h1>React Libraries Examples</h1>}</main>
+    </>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"],
+  "include": ["src", "examples"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- add hash-based navigation header to switch between examples
- expose Dayjs and Zod demos as React components
- include examples directory in TypeScript config

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)

------
https://chatgpt.com/codex/tasks/task_e_689cb57c36a08322a08c3d63bfd06ba0