### PR TITLE
Fix Day.js plugin usage and sample person data

### DIFF
--- a/examples/dayjs.tsx
+++ b/examples/dayjs.tsx
@@ -7,6 +7,7 @@ import duration from "dayjs/plugin/duration";
 import calendar from "dayjs/plugin/calendar";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import weekOfYear from "dayjs/plugin/weekOfYear";
+import dayOfYear from "dayjs/plugin/dayOfYear";
 import "dayjs/locale/es";
 import { useState, useEffect } from "react";
 
@@ -19,6 +20,7 @@ dayjs.extend(duration);
 dayjs.extend(calendar);
 dayjs.extend(advancedFormat);
 dayjs.extend(weekOfYear);
+dayjs.extend(dayOfYear);
 
 // Configurar idioma
 dayjs.locale('es');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,21 @@ const examples = [
   {
     slug: "react-table",
     label: "React Table",
-    element: <Tabla data={[{ name: "Juan", age: 30 }]} />,
+    element: (
+      <Tabla
+        data={[
+          {
+            id: 1,
+            name: "Juan",
+            age: 30,
+            email: "juan@example.com",
+            department: "Engineering",
+            salary: 50000,
+            status: "active",
+          },
+        ]}
+      />
+    ),
   },
   { slug: "zustand", label: "Zustand", element: <ZustandExample /> },
   { slug: "dayjs", label: "Dayjs", element: <DayjsExample /> },


### PR DESCRIPTION
## Summary
- import and extend Day.js dayOfYear plugin so `dayOfYear()` works
- supply full Person object to React Table example to match interface

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689cd9357f708322ba7d88d9e0c30c18