### PR TITLE
feat: add i18n support for all examples

### DIFF
--- a/examples/auth.tsx
+++ b/examples/auth.tsx
@@ -1,4 +1,5 @@
 import { AuthProvider, useAuth } from "../src/lib/auth-context";
+import { Language } from "../src/i18n";
 
 function AuthButton() {
   const { user, isLoading, isAuthenticated, signIn, signOut } = useAuth();
@@ -112,16 +113,38 @@ function AuthButton() {
   );
 }
 // Wrapper que incluye el AuthProvider personalizado
-export default function AuthExample() {
+interface ExampleTranslations {
+  headerTitle: string;
+  headerDescription: string;
+  setupHeading: string;
+}
+
+const translations: Record<Language, ExampleTranslations> = {
+  es: {
+    headerTitle: "🔐 GitHub OAuth",
+    headerDescription:
+      "Autenticación personalizada con GitHub OAuth (sin NextAuth.js)",
+    setupHeading: "📦 Configuración",
+  },
+  en: {
+    headerTitle: "🔐 GitHub OAuth",
+    headerDescription:
+      "Custom authentication with GitHub OAuth (without NextAuth.js)",
+    setupHeading: "📦 Setup",
+  },
+};
+
+export default function AuthExample({ lang = "es" as Language }) {
+  const t = translations[lang];
   return (
     <AuthProvider>
       <div className="page-header">
-        <h2>🔐 GitHub OAuth</h2>
-        <p>Autenticación personalizada con GitHub OAuth (sin NextAuth.js)</p>
+        <h2>{t.headerTitle}</h2>
+        <p>{t.headerDescription}</p>
       </div>
 
       <div className="installation-section">
-        <h3>📦 Configuración</h3>
+        <h3>{t.setupHeading}</h3>
         <div className="installation-code">
           <pre>
             <code>
@@ -232,4 +255,3 @@ export default function AuthExample() {
     </AuthProvider>
   );
 }
-import { useEffect, useState } from "react";

--- a/examples/chartjs.tsx
+++ b/examples/chartjs.tsx
@@ -11,6 +11,7 @@ import {
 } from "chart.js";
 import { Doughnut, Bar, Line } from "react-chartjs-2";
 import { useState } from "react";
+import { Language } from "../src/i18n";
 
 ChartJS.register(
   ArcElement,
@@ -23,70 +24,182 @@ ChartJS.register(
   Legend
 );
 
-const doughnutData = {
-  labels: ["React", "Vue", "Angular", "Svelte"],
-  datasets: [
-    {
-      label: "Popularidad",
-      data: [45, 25, 20, 10],
-      backgroundColor: ["#61dafb", "#4fc08d", "#dd1b16", "#ff3e00"],
-      borderWidth: 2,
-      borderColor: "#fff",
-    },
-  ],
-};
+interface ExampleTranslations {
+  headerTitle: string;
+  headerDescription: string;
+  installHeading: string;
+  installNote: string;
+  chartOptionsTitle: string;
+  buttons: { doughnut: string; bar: string; line: string };
+  chartInfoTitle: string;
+  info: Record<"doughnut" | "bar" | "line", string[]>;
+  doughnutData: { labels: string[]; datasetLabel: string };
+  barData: {
+    labels: string[];
+    currentLabel: string;
+    previousLabel: string;
+  };
+  lineData: { labels: string[]; datasetLabel: string };
+}
 
-const barData = {
-  labels: ["Ene", "Feb", "Mar", "Abr", "May", "Jun"],
-  datasets: [
-    {
-      label: "Ventas 2024",
-      data: [12, 19, 3, 5, 2, 3],
-      backgroundColor: "rgba(99, 102, 241, 0.8)",
-      borderColor: "rgba(99, 102, 241, 1)",
-      borderWidth: 1,
+const translations: Record<Language, ExampleTranslations> = {
+  es: {
+    headerTitle: "📊 Chart.js + React",
+    headerDescription:
+      "Gráficos interactivos y responsivos con Chart.js y react-chartjs-2",
+    installHeading: "📦 Instalación",
+    installNote:
+      "Chart.js es una biblioteca poderosa para crear gráficos HTML5 responsivos y animados.",
+    chartOptionsTitle: "Datos de Ejemplo",
+    buttons: {
+      doughnut: "🍩 Doughnut",
+      bar: "📊 Barras",
+      line: "📈 Líneas",
     },
-    {
-      label: "Ventas 2023",
-      data: [8, 15, 5, 7, 4, 6],
-      backgroundColor: "rgba(34, 197, 94, 0.8)",
-      borderColor: "rgba(34, 197, 94, 1)",
-      borderWidth: 1,
+    chartInfoTitle: "Información del gráfico actual:",
+    info: {
+      doughnut: [
+        "🎯 <strong>Tipo:</strong> Gráfico de dona",
+        "📝 <strong>Uso:</strong> Mostrar proporciones y porcentajes",
+        "✨ <strong>Características:</strong> Interactivo, con tooltips",
+      ],
+      bar: [
+        "🎯 <strong>Tipo:</strong> Gráfico de barras",
+        "📝 <strong>Uso:</strong> Comparar valores entre categorías",
+        "✨ <strong>Características:</strong> Múltiples datasets, responsive",
+      ],
+      line: [
+        "🎯 <strong>Tipo:</strong> Gráfico de líneas",
+        "📝 <strong>Uso:</strong> Mostrar tendencias a lo largo del tiempo",
+        "✨ <strong>Características:</strong> Curvas suaves, área rellena",
+      ],
     },
-  ],
-};
-
-const lineData = {
-  labels: ["Sem 1", "Sem 2", "Sem 3", "Sem 4", "Sem 5", "Sem 6"],
-  datasets: [
-    {
-      label: "Usuarios Activos",
-      data: [1200, 1900, 3000, 5000, 2000, 3000],
-      fill: false,
-      borderColor: "rgb(75, 192, 192)",
-      backgroundColor: "rgba(75, 192, 192, 0.2)",
-      tension: 0.4,
+    doughnutData: {
+      labels: ["React", "Vue", "Angular", "Svelte"],
+      datasetLabel: "Popularidad",
     },
-  ],
-};
-
-const chartOptions = {
-  responsive: true,
-  plugins: {
-    legend: {
-      position: "top" as const,
+    barData: {
+      labels: ["Ene", "Feb", "Mar", "Abr", "May", "Jun"],
+      currentLabel: "Ventas 2024",
+      previousLabel: "Ventas 2023",
     },
-    title: {
-      display: true,
-      text: "Datos de Ejemplo",
+    lineData: {
+      labels: ["Sem 1", "Sem 2", "Sem 3", "Sem 4", "Sem 5", "Sem 6"],
+      datasetLabel: "Usuarios Activos",
+    },
+  },
+  en: {
+    headerTitle: "📊 Chart.js + React",
+    headerDescription:
+      "Interactive and responsive charts with Chart.js and react-chartjs-2",
+    installHeading: "📦 Installation",
+    installNote:
+      "Chart.js is a powerful library for creating responsive, animated HTML5 charts.",
+    chartOptionsTitle: "Sample Data",
+    buttons: {
+      doughnut: "🍩 Doughnut",
+      bar: "📊 Bars",
+      line: "📈 Lines",
+    },
+    chartInfoTitle: "Current chart information:",
+    info: {
+      doughnut: [
+        "🎯 <strong>Type:</strong> Doughnut chart",
+        "📝 <strong>Use:</strong> Display proportions and percentages",
+        "✨ <strong>Features:</strong> Interactive with tooltips",
+      ],
+      bar: [
+        "🎯 <strong>Type:</strong> Bar chart",
+        "📝 <strong>Use:</strong> Compare values across categories",
+        "✨ <strong>Features:</strong> Multiple datasets, responsive",
+      ],
+      line: [
+        "🎯 <strong>Type:</strong> Line chart",
+        "📝 <strong>Use:</strong> Show trends over time",
+        "✨ <strong>Features:</strong> Smooth curves, filled area",
+      ],
+    },
+    doughnutData: {
+      labels: ["React", "Vue", "Angular", "Svelte"],
+      datasetLabel: "Popularity",
+    },
+    barData: {
+      labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+      currentLabel: "Sales 2024",
+      previousLabel: "Sales 2023",
+    },
+    lineData: {
+      labels: ["Week 1", "Week 2", "Week 3", "Week 4", "Week 5", "Week 6"],
+      datasetLabel: "Active Users",
     },
   },
 };
 
-export function ChartJSExample() {
+export function ChartJSExample({ lang }: { lang: Language }) {
   const [activeChart, setActiveChart] = useState<"doughnut" | "bar" | "line">(
     "doughnut"
   );
+  const t = translations[lang];
+
+  const doughnutData = {
+    labels: t.doughnutData.labels,
+    datasets: [
+      {
+        label: t.doughnutData.datasetLabel,
+        data: [45, 25, 20, 10],
+        backgroundColor: ["#61dafb", "#4fc08d", "#dd1b16", "#ff3e00"],
+        borderWidth: 2,
+        borderColor: "#fff",
+      },
+    ],
+  };
+
+  const barData = {
+    labels: t.barData.labels,
+    datasets: [
+      {
+        label: t.barData.currentLabel,
+        data: [12, 19, 3, 5, 2, 3],
+        backgroundColor: "rgba(99, 102, 241, 0.8)",
+        borderColor: "rgba(99, 102, 241, 1)",
+        borderWidth: 1,
+      },
+      {
+        label: t.barData.previousLabel,
+        data: [8, 15, 5, 7, 4, 6],
+        backgroundColor: "rgba(34, 197, 94, 0.8)",
+        borderColor: "rgba(34, 197, 94, 1)",
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const lineData = {
+    labels: t.lineData.labels,
+    datasets: [
+      {
+        label: t.lineData.datasetLabel,
+        data: [1200, 1900, 3000, 5000, 2000, 3000],
+        fill: false,
+        borderColor: "rgb(75, 192, 192)",
+        backgroundColor: "rgba(75, 192, 192, 0.2)",
+        tension: 0.4,
+      },
+    ],
+  };
+
+  const chartOptions = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: "top" as const,
+      },
+      title: {
+        display: true,
+        text: t.chartOptionsTitle,
+      },
+    },
+  };
 
   const renderChart = () => {
     switch (activeChart) {
@@ -104,23 +217,18 @@ export function ChartJSExample() {
   return (
     <div className="page-container">
       <div className="page-header">
-        <h1>📊 Chart.js + React</h1>
-        <p>
-          Gráficos interactivos y responsivos con Chart.js y react-chartjs-2
-        </p>
+        <h1>{t.headerTitle}</h1>
+        <p>{t.headerDescription}</p>
       </div>
 
       <div className="installation-section">
-        <h3>📦 Instalación</h3>
+        <h3>{t.installHeading}</h3>
         <div className="installation-code">
           <pre>
             <code>{`npm install chart.js react-chartjs-2`}</code>
           </pre>
         </div>
-        <p className="installation-note">
-          Chart.js es una biblioteca poderosa para crear gráficos HTML5
-          responsivos y animados.
-        </p>
+        <p className="installation-note">{t.installNote}</p>
       </div>
 
       <div className="chart-demo">
@@ -131,69 +239,30 @@ export function ChartJSExample() {
             }`}
             onClick={() => setActiveChart("doughnut")}
           >
-            🍩 Doughnut
+            {t.buttons.doughnut}
           </button>
           <button
             className={`chart-btn ${activeChart === "bar" ? "active" : ""}`}
             onClick={() => setActiveChart("bar")}
           >
-            📊 Barras
+            {t.buttons.bar}
           </button>
           <button
             className={`chart-btn ${activeChart === "line" ? "active" : ""}`}
             onClick={() => setActiveChart("line")}
           >
-            📈 Líneas
+            {t.buttons.line}
           </button>
         </div>
 
         <div className="chart-container">{renderChart()}</div>
 
         <div className="chart-info">
-          <h3>Información del gráfico actual:</h3>
+          <h3>{t.chartInfoTitle}</h3>
           <ul>
-            {activeChart === "doughnut" && (
-              <>
-                <li>
-                  🎯 <strong>Tipo:</strong> Gráfico de dona
-                </li>
-                <li>
-                  📝 <strong>Uso:</strong> Mostrar proporciones y porcentajes
-                </li>
-                <li>
-                  ✨ <strong>Características:</strong> Interactivo, con tooltips
-                </li>
-              </>
-            )}
-            {activeChart === "bar" && (
-              <>
-                <li>
-                  🎯 <strong>Tipo:</strong> Gráfico de barras
-                </li>
-                <li>
-                  📝 <strong>Uso:</strong> Comparar valores entre categorías
-                </li>
-                <li>
-                  ✨ <strong>Características:</strong> Múltiples datasets,
-                  responsive
-                </li>
-              </>
-            )}
-            {activeChart === "line" && (
-              <>
-                <li>
-                  🎯 <strong>Tipo:</strong> Gráfico de líneas
-                </li>
-                <li>
-                  📝 <strong>Uso:</strong> Mostrar tendencias a lo largo del
-                  tiempo
-                </li>
-                <li>
-                  ✨ <strong>Características:</strong> Curvas suaves, área
-                  rellena
-                </li>
-              </>
-            )}
+            {t.info[activeChart].map((line, i) => (
+              <li key={i} dangerouslySetInnerHTML={{ __html: line }} />
+            ))}
           </ul>
         </div>
       </div>

--- a/examples/dayjs.tsx
+++ b/examples/dayjs.tsx
@@ -10,6 +10,31 @@ import weekOfYear from "dayjs/plugin/weekOfYear";
 import dayOfYear from "dayjs/plugin/dayOfYear";
 import "dayjs/locale/es";
 import { useState, useEffect } from "react";
+import { Language } from "../src/i18n";
+
+interface ExampleTranslations {
+  headerTitle: string;
+  headerDescription: string;
+  installHeading: string;
+  installNote: string;
+}
+
+const translations: Record<Language, ExampleTranslations> = {
+  es: {
+    headerTitle: "📅 Day.js",
+    headerDescription: "Manipulación de fechas ligera y moderna",
+    installHeading: "📦 Instalación",
+    installNote:
+      "Day.js es una biblioteca ligera para manejar fechas y tiempos en JavaScript.",
+  },
+  en: {
+    headerTitle: "📅 Day.js",
+    headerDescription: "Lightweight, modern date manipulation",
+    installHeading: "📦 Installation",
+    installNote:
+      "Day.js is a lightweight library for handling dates and times in JavaScript.",
+  },
+};
 
 // Configurar plugins
 dayjs.extend(relativeTime);
@@ -22,9 +47,6 @@ dayjs.extend(advancedFormat);
 dayjs.extend(weekOfYear);
 dayjs.extend(dayOfYear);
 
-// Configurar idioma
-dayjs.locale("es");
-
 interface DateOperation {
   title: string;
   description: string;
@@ -33,7 +55,9 @@ interface DateOperation {
   category: string;
 }
 
-export default function DayjsExample() {
+export default function DayjsExample({ lang }: { lang: Language }) {
+  dayjs.locale(lang);
+  const t = translations[lang];
   const [currentTime, setCurrentTime] = useState(dayjs());
   const [selectedTimezone, setSelectedTimezone] = useState(
     "America/Mexico_City"
@@ -210,24 +234,18 @@ export default function DayjsExample() {
   return (
     <div className="page-container">
       <div className="page-header">
-        <h1>📅 Day.js</h1>
-        <p>
-          Biblioteca minimalista para manipular, validar, formatear y mostrar
-          fechas
-        </p>
+        <h1>{t.headerTitle}</h1>
+        <p>{t.headerDescription}</p>
       </div>
 
       <div className="installation-section">
-        <h3>📦 Instalación</h3>
+        <h3>{t.installHeading}</h3>
         <div className="installation-code">
           <pre>
             <code>{`npm install dayjs`}</code>
           </pre>
         </div>
-        <p className="installation-note">
-          Day.js es una alternativa minimalista a Moment.js con API similar pero
-          solo 2kB.
-        </p>
+        <p className="installation-note">{t.installNote}</p>
       </div>
 
       <div className="dayjs-demo">

--- a/examples/drag-and-drop.tsx
+++ b/examples/drag-and-drop.tsx
@@ -1,5 +1,6 @@
 import { useDragAndDrop } from "@formkit/drag-and-drop/react";
 import { useState } from "react";
+import { Language } from "../src/i18n";
 
 interface Task {
   id: string;
@@ -7,7 +8,46 @@ interface Task {
   completed: boolean;
 }
 
-export default function DragAndDropExample() {
+interface ExampleTranslations {
+  headerTitle: string;
+  headerDescription: string;
+  installHeading: string;
+  installNote: string;
+  addPlaceholder: string;
+  addButton: string;
+  stats: { total: string; completed: string; pending: string };
+  codeExampleTitle: string;
+}
+
+const translations: Record<Language, ExampleTranslations> = {
+  es: {
+    headerTitle: "🎯 Lista de tareas Drag & Drop",
+    headerDescription:
+      "Arrastra las tareas para reordenarlas. Usa la biblioteca @formkit/drag-and-drop",
+    installHeading: "📦 Instalación",
+    installNote:
+      "FormKit Drag and Drop es una biblioteca liviana y flexible para funcionalidad drag & drop.",
+    addPlaceholder: "Agregar nueva tarea...",
+    addButton: "➕ Agregar",
+    stats: { total: "Total", completed: "Completadas", pending: "Pendientes" },
+    codeExampleTitle: "📖 Código de ejemplo:",
+  },
+  en: {
+    headerTitle: "🎯 Drag & Drop Task List",
+    headerDescription:
+      "Drag tasks to reorder them. Uses the @formkit/drag-and-drop library",
+    installHeading: "📦 Installation",
+    installNote:
+      "FormKit Drag and Drop is a lightweight and flexible library for drag & drop functionality.",
+    addPlaceholder: "Add new task...",
+    addButton: "➕ Add",
+    stats: { total: "Total", completed: "Completed", pending: "Pending" },
+    codeExampleTitle: "📖 Example code:",
+  },
+};
+
+export default function DragAndDropExample({ lang }: { lang: Language }) {
+  const t = translations[lang];
   const [newTask, setNewTask] = useState("");
 
   const [ref, tasks, setTasks] = useDragAndDrop<HTMLDivElement, Task>([
@@ -44,24 +84,18 @@ export default function DragAndDropExample() {
   return (
     <div className="page-container">
       <div className="page-header">
-        <h1>🎯 Drag & Drop Task List</h1>
-        <p>
-          Arrastra las tareas para reordenarlas. Usa la biblioteca
-          @formkit/drag-and-drop
-        </p>
+        <h1>{t.headerTitle}</h1>
+        <p>{t.headerDescription}</p>
       </div>
 
       <div className="installation-section">
-        <h3>📦 Instalación</h3>
+        <h3>{t.installHeading}</h3>
         <div className="installation-code">
           <pre>
             <code>{`npm install @formkit/drag-and-drop`}</code>
           </pre>
         </div>
-        <p className="installation-note">
-          FormKit Drag and Drop es una biblioteca liviana y flexible para
-          funcionalidad drag & drop.
-        </p>
+        <p className="installation-note">{t.installNote}</p>
       </div>
 
       <div className="drag-drop-demo">
@@ -71,12 +105,12 @@ export default function DragAndDropExample() {
               type="text"
               value={newTask}
               onChange={(e) => setNewTask(e.target.value)}
-              placeholder="Agregar nueva tarea..."
+              placeholder={t.addPlaceholder}
               className="task-input"
               onKeyPress={(e) => e.key === "Enter" && addTask()}
             />
             <button onClick={addTask} className="add-btn">
-              ➕ Agregar
+              {t.addButton}
             </button>
           </div>
         </div>
@@ -110,14 +144,20 @@ export default function DragAndDropExample() {
         </div>
 
         <div className="stats">
-          <p>Total: {tasks.length} tareas</p>
-          <p>Completadas: {tasks.filter((t) => t.completed).length}</p>
-          <p>Pendientes: {tasks.filter((t) => !t.completed).length}</p>
+          <p>
+            {t.stats.total}: {tasks.length}
+          </p>
+          <p>
+            {t.stats.completed}: {tasks.filter((t) => t.completed).length}
+          </p>
+          <p>
+            {t.stats.pending}: {tasks.filter((t) => !t.completed).length}
+          </p>
         </div>
       </div>
 
       <div className="code-example">
-        <h3>📖 Código de ejemplo:</h3>
+        <h3>{t.codeExampleTitle}</h3>
         <pre>
           {`import { useDragAndDrop } from "@formkit/drag-and-drop/react";
 

--- a/examples/fontsource.tsx
+++ b/examples/fontsource.tsx
@@ -3,33 +3,46 @@ import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
 import { useState } from "react";
+import { Language } from "../src/i18n";
 
 const fontExamples = [
   {
     name: "Roboto",
     family: "Roboto, sans-serif",
-    description: "Fuente moderna y legible de Google",
+    description: {
+      es: "Fuente moderna y legible de Google",
+      en: "Modern and readable Google font",
+    },
     weights: ["300", "400", "500", "700"],
     category: "Sans Serif",
   },
   {
     name: "Arial",
     family: "Arial, sans-serif",
-    description: "Fuente clásica disponible en todos los sistemas",
+    description: {
+      es: "Fuente clásica disponible en todos los sistemas",
+      en: "Classic font available on all systems",
+    },
     weights: ["400", "700"],
     category: "Sans Serif",
   },
   {
     name: "Georgia",
     family: "Georgia, serif",
-    description: "Fuente serif optimizada para pantalla",
+    description: {
+      es: "Fuente serif optimizada para pantalla",
+      en: "Serif font optimized for screen",
+    },
     weights: ["400", "700"],
     category: "Serif",
   },
   {
     name: "Courier New",
     family: "Courier New, monospace",
-    description: "Fuente monospace clásica para código",
+    description: {
+      es: "Fuente monospace clásica para código",
+      en: "Classic monospace font for code",
+    },
     weights: ["400"],
     category: "Monospace",
   },
@@ -38,22 +51,106 @@ const fontExamples = [
 const sampleTexts = {
   paragraph:
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-  title: "El Zorro Veloz Salta Sobre el Perro Perezoso",
+  title: {
+    es: "El Zorro Veloz Salta Sobre el Perro Perezoso",
+    en: "The Quick Brown Fox Jumps Over the Lazy Dog",
+  },
   code: "const greeting = 'Hello World!';\nconsole.log(greeting);",
   numbers: "0123456789 + - = * / () [] {}",
+};
+
+interface ExampleTranslations {
+  headerTitle: string;
+  headerDescription: string;
+  installHeading: string;
+  installOtherFont: string;
+  installNote: string;
+  textTypeHeading: string;
+  textButtons: { paragraph: string; title: string; code: string; numbers: string };
+  filterHeading: string;
+  allFonts: string;
+  comparisonHeading: string;
+  installGuideHeading: string;
+  installSteps: [string, string, string];
+  featuresHeading: string;
+  features: { title: string; description: string }[];
+  codeExampleHeading: string;
+  orJsx: string;
+  robotoText: string;
+}
+
+const translations: Record<Language, ExampleTranslations> = {
+  es: {
+    headerTitle: "🔤 Fontsource",
+    headerDescription: "Fuentes web auto-hospedadas para proyectos npm",
+    installHeading: "📦 Instalación",
+    installOtherFont: "O cualquier otra fuente específica",
+    installNote: "Fontsource permite auto-hospedar fuentes de Google Fonts en tu proyecto npm.",
+    textTypeHeading: "📝 Tipo de texto:",
+    textButtons: { paragraph: "Párrafo", title: "Título", code: "Código", numbers: "Números" },
+    filterHeading: "🎯 Filtrar por fuente:",
+    allFonts: "Todas",
+    comparisonHeading: "📊 Comparación lado a lado:",
+    installGuideHeading: "📦 Guía de Instalación:",
+    installSteps: [
+      "Instalar la fuente",
+      "Importar en tu componente",
+      "Usar en CSS o inline",
+    ],
+    featuresHeading: "✨ Ventajas de Fontsource:",
+    features: [
+      { title: "🚀 Auto-hospedado", description: "No dependes de CDNs externos, mejor rendimiento" },
+      { title: "📦 NPM", description: "Instalación y versionado como cualquier paquete" },
+      { title: "🎛️ Control granular", description: "Importa solo los pesos y estilos que necesitas" },
+      { title: "🔒 Offline", description: "Funciona sin conexión a internet" },
+    ],
+    codeExampleHeading: "📖 Código de ejemplo:",
+    orJsx: "O directamente en JSX",
+    robotoText: "Texto con Roboto",
+  },
+  en: {
+    headerTitle: "🔤 Fontsource",
+    headerDescription: "Self-hosted web fonts for npm projects",
+    installHeading: "📦 Installation",
+    installOtherFont: "Or any other specific font",
+    installNote: "Fontsource lets you self-host Google Fonts in your npm project.",
+    textTypeHeading: "📝 Text type:",
+    textButtons: { paragraph: "Paragraph", title: "Title", code: "Code", numbers: "Numbers" },
+    filterHeading: "🎯 Filter by font:",
+    allFonts: "All",
+    comparisonHeading: "📊 Side-by-side comparison:",
+    installGuideHeading: "📦 Installation Guide:",
+    installSteps: [
+      "Install the font",
+      "Import in your component",
+      "Use in CSS or inline",
+    ],
+    featuresHeading: "✨ Fontsource advantages:",
+    features: [
+      { title: "🚀 Self-hosted", description: "No external CDNs, better performance" },
+      { title: "📦 NPM", description: "Install and version like any package" },
+      { title: "🎛️ Granular control", description: "Import only the weights and styles you need" },
+      { title: "🔒 Offline", description: "Works without internet connection" },
+    ],
+    codeExampleHeading: "📖 Example code:",
+    orJsx: "Or directly in JSX",
+    robotoText: "Text with Roboto",
+  },
 };
 
 function FontDemo({
   font,
   selectedText,
+  lang,
 }: {
   font: (typeof fontExamples)[0];
   selectedText: string;
+  lang: Language;
 }) {
   const getText = () => {
     switch (selectedText) {
       case "title":
-        return sampleTexts.title;
+        return sampleTexts.title[lang];
       case "code":
         return sampleTexts.code;
       case "numbers":
@@ -69,7 +166,7 @@ function FontDemo({
         <h3>{font.name}</h3>
         <span className="font-category">{font.category}</span>
       </div>
-      <p className="font-description">{font.description}</p>
+      <p className="font-description">{font.description[lang]}</p>
 
       <div className="font-weights">
         <strong>Pesos disponibles:</strong>
@@ -108,36 +205,34 @@ function FontDemo({
   );
 }
 
-export default function FontsourceExample() {
+export default function FontsourceExample({ lang }: { lang: Language }) {
+  const t = translations[lang];
   const [selectedText, setSelectedText] = useState("paragraph");
   const [selectedFont, setSelectedFont] = useState<string | null>(null);
 
   return (
     <div className="page-container">
       <div className="page-header">
-        <h1>🔤 Fontsource</h1>
-        <p>Fuentes web auto-hospedadas para proyectos npm</p>
+        <h1>{t.headerTitle}</h1>
+        <p>{t.headerDescription}</p>
       </div>
 
       <div className="installation-section">
-        <h3>📦 Instalación</h3>
+        <h3>{t.installHeading}</h3>
         <div className="installation-code">
           <pre>
             <code>{`npm install @fontsource/roboto
-# O cualquier otra fuente específica
+# ${t.installOtherFont}
 npm install @fontsource/inter`}</code>
           </pre>
         </div>
-        <p className="installation-note">
-          Fontsource permite auto-hospedar fuentes de Google Fonts en tu
-          proyecto npm.
-        </p>
+        <p className="installation-note">{t.installNote}</p>
       </div>
 
       <div className="fontsource-demo">
         <div className="demo-controls">
           <div className="text-controls">
-            <h3>📝 Tipo de texto:</h3>
+            <h3>{t.textTypeHeading}</h3>
             <div className="text-buttons">
               <button
                 className={`btn ${
@@ -145,7 +240,7 @@ npm install @fontsource/inter`}</code>
                 }`}
                 onClick={() => setSelectedText("paragraph")}
               >
-                📄 Párrafo
+                📄 {t.textButtons.paragraph}
               </button>
               <button
                 className={`btn ${
@@ -153,7 +248,7 @@ npm install @fontsource/inter`}</code>
                 }`}
                 onClick={() => setSelectedText("title")}
               >
-                📰 Título
+                📰 {t.textButtons.title}
               </button>
               <button
                 className={`btn ${
@@ -161,7 +256,7 @@ npm install @fontsource/inter`}</code>
                 }`}
                 onClick={() => setSelectedText("code")}
               >
-                💻 Código
+                💻 {t.textButtons.code}
               </button>
               <button
                 className={`btn ${
@@ -169,13 +264,13 @@ npm install @fontsource/inter`}</code>
                 }`}
                 onClick={() => setSelectedText("numbers")}
               >
-                🔢 Números
+                🔢 {t.textButtons.numbers}
               </button>
             </div>
           </div>
 
           <div className="font-filter">
-            <h3>🎯 Filtrar por fuente:</h3>
+            <h3>{t.filterHeading}</h3>
             <div className="font-buttons">
               <button
                 className={`btn ${
@@ -183,7 +278,7 @@ npm install @fontsource/inter`}</code>
                 }`}
                 onClick={() => setSelectedFont(null)}
               >
-                📋 Todas
+                📋 {t.allFonts}
               </button>
               {fontExamples.map((font) => (
                 <button
@@ -206,12 +301,12 @@ npm install @fontsource/inter`}</code>
               (font) => selectedFont === null || font.name === selectedFont
             )
             .map((font, index) => (
-              <FontDemo key={index} font={font} selectedText={selectedText} />
+              <FontDemo key={index} font={font} selectedText={selectedText} lang={lang} />
             ))}
         </div>
 
         <div className="comparison-section">
-          <h3>📊 Comparación lado a lado:</h3>
+          <h3>{t.comparisonHeading}</h3>
           <div className="comparison-grid">
             {fontExamples.map((font) => (
               <div key={font.name} className="comparison-item">
@@ -228,19 +323,19 @@ npm install @fontsource/inter`}</code>
         </div>
 
         <div className="installation-guide">
-          <h3>📦 Guía de Instalación:</h3>
+          <h3>{t.installGuideHeading}</h3>
           <div className="install-steps">
             <div className="install-step">
-              <h4>1. Instalar la fuente</h4>
+              <h4>{t.installSteps[0]}</h4>
               <pre className="install-code">npm install @fontsource/roboto</pre>
             </div>
             <div className="install-step">
-              <h4>2. Importar en tu componente</h4>
+              <h4>{t.installSteps[1]}</h4>
               <pre className="install-code">{`import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/700.css";`}</pre>
             </div>
             <div className="install-step">
-              <h4>3. Usar en CSS o inline</h4>
+              <h4>{t.installSteps[2]}</h4>
               <pre className="install-code">{`.my-text {
   font-family: 'Roboto', sans-serif;
 }`}</pre>
@@ -250,46 +345,36 @@ import "@fontsource/roboto/700.css";`}</pre>
       </div>
 
       <div className="fontsource-features">
-        <h3>✨ Ventajas de Fontsource:</h3>
+        <h3>{t.featuresHeading}</h3>
         <div className="features-grid">
-          <div className="feature">
-            <h4>🚀 Auto-hospedado</h4>
-            <p>No dependes de CDNs externos, mejor rendimiento</p>
-          </div>
-          <div className="feature">
-            <h4>📦 NPM</h4>
-            <p>Instalación y versionado como cualquier paquete</p>
-          </div>
-          <div className="feature">
-            <h4>🎛️ Control granular</h4>
-            <p>Importa solo los pesos y estilos que necesitas</p>
-          </div>
-          <div className="feature">
-            <h4>🔒 Offline</h4>
-            <p>Funciona sin conexión a internet</p>
-          </div>
+          {t.features.map((feature: { title: string; description: string }) => (
+            <div key={feature.title} className="feature">
+              <h4>{feature.title}</h4>
+              <p>{feature.description}</p>
+            </div>
+          ))}
         </div>
       </div>
 
       <div className="code-example">
-        <h3>📖 Código de ejemplo:</h3>
+        <h3>{t.codeExampleHeading}</h3>
         <pre>
-          {`// 1. Instalar fuente
+          {`// 1. ${t.installSteps[0]}
 npm install @fontsource/roboto
 
-// 2. Importar en tu componente
+// 2. ${t.installSteps[1]}
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/700.css";
 
-// 3. Usar en CSS
+// 3. ${t.installSteps[2]}
 .my-text {
   font-family: 'Roboto', sans-serif;
   font-weight: 400;
 }
 
-// O directamente en JSX
+// ${t.orJsx}
 <div style={{ fontFamily: 'Roboto, sans-serif' }}>
-  Texto con Roboto
+  ${t.robotoText}
 </div>`}
         </pre>
       </div>

--- a/examples/hotkeys.tsx
+++ b/examples/hotkeys.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import hotkeys from "hotkeys-js";
+import { Language } from "../src/i18n";
 
 interface HotkeyAction {
   key: string;
@@ -15,7 +16,34 @@ interface LogEntry {
   description: string;
 }
 
-export default function HotkeysExample() {
+interface ExampleTranslations {
+  headerTitle: string;
+  headerDescription: string;
+  installHeading: string;
+  installNote: string;
+}
+
+const translations: Record<Language, ExampleTranslations> = {
+  es: {
+    headerTitle: "⌨️ Hotkeys.js",
+    headerDescription:
+      "Atajos de teclado poderosos y flexibles para aplicaciones web",
+    installHeading: "📦 Instalación",
+    installNote:
+      "Hotkeys.js es una biblioteca robusta para manejar atajos de teclado en aplicaciones web.",
+  },
+  en: {
+    headerTitle: "⌨️ Hotkeys.js",
+    headerDescription:
+      "Powerful and flexible keyboard shortcuts for web applications",
+    installHeading: "📦 Installation",
+    installNote:
+      "Hotkeys.js is a robust library for handling keyboard shortcuts in web apps.",
+  },
+};
+
+export default function HotkeysExample({ lang }: { lang: Language }) {
+  const t = translations[lang];
   const [log, setLog] = useState<LogEntry[]>([]);
   const [counter, setCounter] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -149,21 +177,18 @@ export default function HotkeysExample() {
   return (
     <div className={`page-container ${theme === "dark" ? "dark-theme" : ""}`}>
       <div className="page-header">
-        <h1>⌨️ Hotkeys.js</h1>
-        <p>Atajos de teclado poderosos y flexibles para aplicaciones web</p>
+        <h1>{t.headerTitle}</h1>
+        <p>{t.headerDescription}</p>
       </div>
 
       <div className="installation-section">
-        <h3>📦 Instalación</h3>
+        <h3>{t.installHeading}</h3>
         <div className="installation-code">
           <pre>
             <code>{`npm install hotkeys-js`}</code>
           </pre>
         </div>
-        <p className="installation-note">
-          Hotkeys.js es una biblioteca robusta para manejar atajos de teclado en
-          aplicaciones web.
-        </p>
+        <p className="installation-note">{t.installNote}</p>
       </div>
 
       {/* Notificaciones */}

--- a/examples/motion.tsx
+++ b/examples/motion.tsx
@@ -1,5 +1,6 @@
 import { motion, AnimatePresence } from "framer-motion";
 import { useState } from "react";
+import { Language } from "../src/i18n";
 
 const animationVariants = {
   fadeIn: {
@@ -117,7 +118,32 @@ function StaggeredList() {
   );
 }
 
-export default function FramerMotionExample() {
+interface ExampleTranslations {
+  headerTitle: string;
+  headerDescription: string;
+  installHeading: string;
+  installNote: string;
+}
+
+const translations: Record<Language, ExampleTranslations> = {
+  es: {
+    headerTitle: "✨ Framer Motion",
+    headerDescription: "Animaciones fluidas y gestos interactivos para React",
+    installHeading: "📦 Instalación",
+    installNote:
+      "Framer Motion es una biblioteca de animación lista para producción para React.",
+  },
+  en: {
+    headerTitle: "✨ Framer Motion",
+    headerDescription: "Smooth animations and interactive gestures for React",
+    installHeading: "📦 Installation",
+    installNote:
+      "Framer Motion is a production-ready animation library for React.",
+  },
+};
+
+export default function FramerMotionExample({ lang }: { lang: Language }) {
+  const t = translations[lang];
   const [currentAnimation, setCurrentAnimation] =
     useState<keyof typeof animationVariants>("fadeIn");
   const [showElement, setShowElement] = useState(true);
@@ -139,21 +165,18 @@ export default function FramerMotionExample() {
   return (
     <div className="page-container">
       <div className="page-header">
-        <h1>✨ Framer Motion</h1>
-        <p>Animaciones fluidas y gestos interactivos para React</p>
+        <h1>{t.headerTitle}</h1>
+        <p>{t.headerDescription}</p>
       </div>
 
       <div className="installation-section">
-        <h3>📦 Instalación</h3>
+        <h3>{t.installHeading}</h3>
         <div className="installation-code">
           <pre>
             <code>{`npm install framer-motion`}</code>
           </pre>
         </div>
-        <p className="installation-note">
-          Framer Motion es una biblioteca de animación lista para producción
-          para React.
-        </p>
+        <p className="installation-note">{t.installNote}</p>
       </div>
 
       <div className="motion-demo">

--- a/examples/react-table.tsx
+++ b/examples/react-table.tsx
@@ -10,6 +10,7 @@ import {
   ColumnFiltersState,
 } from "@tanstack/react-table";
 import { useState } from "react";
+import { Language } from "../src/i18n";
 
 interface Person {
   id: number;
@@ -156,7 +157,32 @@ const columns: ColumnDef<Person>[] = [
   },
 ];
 
-export function ReactTableExample() {
+interface ExampleTranslations {
+  headerTitle: string;
+  headerDescription: string;
+  installHeading: string;
+  installNote: string;
+}
+
+const translations: Record<Language, ExampleTranslations> = {
+  es: {
+    headerTitle: "📊 React Table (TanStack Table)",
+    headerDescription: "Tabla potente con ordenamiento, filtrado, paginación y más",
+    installHeading: "📦 Instalación",
+    installNote:
+      "TanStack Table es una biblioteca headless para construir tablas poderosas y flexibles.",
+  },
+  en: {
+    headerTitle: "📊 React Table (TanStack Table)",
+    headerDescription: "Powerful table with sorting, filtering, pagination and more",
+    installHeading: "📦 Installation",
+    installNote:
+      "TanStack Table is a headless library for building powerful, flexible tables.",
+  },
+};
+
+export function ReactTableExample({ lang }: { lang: Language }) {
+  const t = translations[lang];
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
@@ -186,21 +212,18 @@ export function ReactTableExample() {
   return (
     <div className="page-container">
       <div className="page-header">
-        <h1>📊 React Table (TanStack Table)</h1>
-        <p>Tabla potente con ordenamiento, filtrado, paginación y más</p>
+        <h1>{t.headerTitle}</h1>
+        <p>{t.headerDescription}</p>
       </div>
 
       <div className="installation-section">
-        <h3>📦 Instalación</h3>
+        <h3>{t.installHeading}</h3>
         <div className="installation-code">
           <pre>
             <code>{`npm install @tanstack/react-table`}</code>
           </pre>
         </div>
-        <p className="installation-note">
-          TanStack Table es una biblioteca headless para construir tablas
-          poderosas y flexibles.
-        </p>
+        <p className="installation-note">{t.installNote}</p>
       </div>
 
       <div className="table-demo">
@@ -428,6 +451,6 @@ function Table({ data }) {
 }
 
 // Mantenemos la función original para compatibilidad
-export function Tabla({ data }: { data: Person[] }) {
-  return <ReactTableExample />;
+export function Tabla({ data, lang }: { data: Person[]; lang: Language }) {
+  return <ReactTableExample lang={lang} />;
 }

--- a/examples/zod.tsx
+++ b/examples/zod.tsx
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { useState } from "react";
+import { Language } from "../src/i18n";
 
 // Esquemas de ejemplo
 const UserSchema = z.object({
@@ -58,7 +59,34 @@ interface ValidationExample {
   description: string;
 }
 
-export default function ZodExample() {
+interface ExampleTranslations {
+  headerTitle: string;
+  headerDescription: string;
+  installHeading: string;
+  installNote: string;
+}
+
+const translations: Record<Language, ExampleTranslations> = {
+  es: {
+    headerTitle: "🛡️ Zod",
+    headerDescription:
+      "Validación de esquemas TypeScript-first con inferencia de tipos estática",
+    installHeading: "📦 Instalación",
+    installNote:
+      "Zod es una biblioteca de validación de esquemas TypeScript-first con inferencia de tipos estática.",
+  },
+  en: {
+    headerTitle: "🛡️ Zod",
+    headerDescription:
+      "TypeScript-first schema validation with static type inference",
+    installHeading: "📦 Installation",
+    installNote:
+      "Zod is a TypeScript-first schema validation library with static type inference.",
+  },
+};
+
+export default function ZodExample({ lang }: { lang: Language }) {
+  const t = translations[lang];
   const [selectedExample, setSelectedExample] = useState(0);
   const [customData, setCustomData] = useState("");
   const [validationResult, setValidationResult] = useState<any>(null);
@@ -186,24 +214,18 @@ export default function ZodExample() {
   return (
     <div className="page-container">
       <div className="page-header">
-        <h1>🛡️ Zod</h1>
-        <p>
-          Validación de esquemas TypeScript-first con inferencia de tipos
-          estática
-        </p>
+        <h1>{t.headerTitle}</h1>
+        <p>{t.headerDescription}</p>
       </div>
 
       <div className="installation-section">
-        <h3>📦 Instalación</h3>
+        <h3>{t.installHeading}</h3>
         <div className="installation-code">
           <pre>
             <code>{`npm install zod`}</code>
           </pre>
         </div>
-        <p className="installation-note">
-          Zod es una biblioteca de validación de esquemas TypeScript-first con
-          inferencia de tipos estática.
-        </p>
+        <p className="installation-note">{t.installNote}</p>
       </div>
 
       <div className="zod-demo">

--- a/examples/zustand.tsx
+++ b/examples/zustand.tsx
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { Language } from "../src/i18n";
 
 // Store para contador simple
 type CounterStore = {
@@ -167,25 +168,47 @@ function TodoList() {
   );
 }
 
-export function ZustandExample() {
+interface ExampleTranslations {
+  headerTitle: string;
+  headerDescription: string;
+  installHeading: string;
+  installNote: string;
+}
+
+const translations: Record<Language, ExampleTranslations> = {
+  es: {
+    headerTitle: "🐻 Zustand State Management",
+    headerDescription: "Gestión de estado simple y potente sin boilerplate",
+    installHeading: "📦 Instalación",
+    installNote:
+      "Zustand es una solución de gestión de estado pequeña, rápida y escalable.",
+  },
+  en: {
+    headerTitle: "🐻 Zustand State Management",
+    headerDescription: "Simple and powerful state management without boilerplate",
+    installHeading: "📦 Installation",
+    installNote:
+      "Zustand is a small, fast and scalable state management solution.",
+  },
+};
+
+export function ZustandExample({ lang }: { lang: Language }) {
+  const t = translations[lang];
   return (
     <div className="page-container">
       <div className="page-header">
-        <h1>🐻 Zustand State Management</h1>
-        <p>Gestión de estado simple y potente sin boilerplate</p>
+        <h1>{t.headerTitle}</h1>
+        <p>{t.headerDescription}</p>
       </div>
 
       <div className="installation-section">
-        <h3>📦 Instalación</h3>
+        <h3>{t.installHeading}</h3>
         <div className="installation-code">
           <pre>
             <code>{`npm install zustand`}</code>
           </pre>
         </div>
-        <p className="installation-note">
-          Zustand es una solución de gestión de estado pequeña, rápida y
-          escalable.
-        </p>
+        <p className="installation-note">{t.installNote}</p>
       </div>
 
       <div className="zustand-demo">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,19 +14,35 @@ import ZodExample from "../examples/zod";
 import AuthExample from "../examples/auth";
 
 const examples = [
-  { slug: "chartjs", label: "ChartJS", element: <ChartJSExample /> },
+  {
+    slug: "chartjs",
+    label: "ChartJS",
+    element: (lang: Language) => <ChartJSExample lang={lang} />,
+  },
   {
     slug: "drag-and-drop",
     label: "Drag & Drop",
-    element: <DragAndDropExample />,
+    element: (lang: Language) => <DragAndDropExample lang={lang} />,
   },
-  { slug: "fontsource", label: "Fontsource", element: <FontsourceExample /> },
-  { slug: "hotkeys", label: "Hotkeys", element: <HotkeysExample /> },
-  { slug: "motion", label: "Motion", element: <FramerMotionExample /> },
+  {
+    slug: "fontsource",
+    label: "Fontsource",
+    element: (lang: Language) => <FontsourceExample lang={lang} />,
+  },
+  {
+    slug: "hotkeys",
+    label: "Hotkeys",
+    element: (lang: Language) => <HotkeysExample lang={lang} />,
+  },
+  {
+    slug: "motion",
+    label: "Motion",
+    element: (lang: Language) => <FramerMotionExample lang={lang} />,
+  },
   {
     slug: "react-table",
     label: "React Table",
-    element: (
+    element: (lang: Language) => (
       <Tabla
         data={[
           {
@@ -39,12 +55,25 @@ const examples = [
             status: "active",
           },
         ]}
+        lang={lang}
       />
     ),
   },
-  { slug: "zustand", label: "Zustand", element: <ZustandExample /> },
-  { slug: "dayjs", label: "Dayjs", element: <DayjsExample /> },
-  { slug: "zod", label: "Zod", element: <ZodExample /> },
+  {
+    slug: "zustand",
+    label: "Zustand",
+    element: (lang: Language) => <ZustandExample lang={lang} />,
+  },
+  {
+    slug: "dayjs",
+    label: "Dayjs",
+    element: (lang: Language) => <DayjsExample lang={lang} />,
+  },
+  {
+    slug: "zod",
+    label: "Zod",
+    element: (lang: Language) => <ZodExample lang={lang} />,
+  },
 ];
 
 function HomePage({ lang }: { lang: Language }) {
@@ -138,9 +167,9 @@ export default function App() {
   // Manejar caso especial para auth (no en navegación pero accesible)
   const renderContent = () => {
     if (example === "auth") {
-      return <AuthExample />;
+      return <AuthExample lang={lang} />;
     }
-    return current ? current.element : <HomePage lang={lang} />;
+    return current ? current.element(lang) : <HomePage lang={lang} />;
   };
 
   const handleLinkClick = () => {


### PR DESCRIPTION
## Summary
- localize remaining example pages with basic English and Spanish text
- pass selected language into every demo component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dd4bca08c83228951e4905258dccc